### PR TITLE
Fix init-patient saga

### DIFF
--- a/src/sagas/__tests__/init-active-patient-test.js
+++ b/src/sagas/__tests__/init-active-patient-test.js
@@ -1,13 +1,17 @@
 /* eslint-env jest */
 
 jest.unmock('redux-saga/effects');
+jest.unmock('redux-saga');
 jest.unmock('react-redux-form');
 jest.unmock('../../actions');
 jest.unmock('../init-active-patient');
 
 import { createId } from '../../utils';
-import { put } from 'redux-saga/effects';
+import { put, call } from 'redux-saga/effects';
+import { delay } from 'redux-saga';
 import {
+  requestFetchPatient,
+  successFetchPatient,
   changeActivePatient,
   resetActiveRecords,
 } from '../../actions';
@@ -20,6 +24,12 @@ describe('INIT_ACTIVE_PATIENT', () => {
     const saga = initActivePatient();
 
     expect(saga.next().value)
+      .toEqual(put(requestFetchPatient()));
+
+    expect(saga.next().value)
+      .toEqual(call(delay, 100));
+
+    expect(saga.next().value)
       .toEqual(put(changeActivePatient({
         _id: 'patient_thisismockedid',
         type: 'patient',
@@ -29,6 +39,9 @@ describe('INIT_ACTIVE_PATIENT', () => {
 
     expect(saga.next().value)
       .toEqual(put(resetActiveRecords()));
+
+    expect(saga.next().value)
+      .toEqual(put(successFetchPatient()));
 
     expect(saga.next())
       .toEqual({ done: true, value: undefined });

--- a/src/sagas/init-active-patient.js
+++ b/src/sagas/init-active-patient.js
@@ -1,6 +1,9 @@
 import { take, put, call } from 'redux-saga/effects';
+import { delay } from 'redux-saga';
 import {
   INIT_ACTIVE_PATIENT,
+  requestFetchPatient,
+  successFetchPatient,
   changeActivePatient,
   resetActiveRecords,
 } from '../actions';
@@ -9,6 +12,12 @@ import {
 } from '../utils';
 
 export function* initActivePatient() {
+  // FIXME:
+  // requestFetchPatient, delay, and successFetchPatient are just work-around
+  // to solve https://github.com/asha-nepal/AshaFusionCross/issues/419
+  yield put(requestFetchPatient());
+  yield call(delay, 100);
+
   const id = createId(16);
   yield put(changeActivePatient({
     _id: `patient_${id}`,
@@ -17,6 +26,8 @@ export function* initActivePatient() {
     silent: true,
   }));
   yield put(resetActiveRecords());
+
+  yield put(successFetchPatient());
 }
 
 export function* watchInitActivePatient() {


### PR DESCRIPTION
init-patient sagaによるpatient, recordsの初期化が非同期で起きるので、react-redux-formのレンダリングタイミングと競合する？
fetch-patient sagaもfetchの時間でたまたまうまくいっていただけだった。
work aroundとしてinit-patientのほうにdelayを入れた。
根本解決はToDo