### PR TITLE
(refs #516) Replace target S3 bucket name and prefix with variables

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -81,7 +81,7 @@ web-build-and-upload:
       key-id: $AWS_ACCESS_KEY_ID
       key-secret: $AWS_SECRET_ACCESS_KEY
       file: ${ZIP_ARCHIVE_NAME}
-      url: s3://asha-fusion-archive/webapp/${ZIP_ARCHIVE_NAME}
+      url: s3://${S3_BUCKET_DEPLOY_TO}/${S3_PREFIX}/${ZIP_ARCHIVE_NAME}
 
 electron-build-and-upload:
   box: node:6.10
@@ -117,7 +117,7 @@ electron-build-and-upload:
       key-id: $AWS_ACCESS_KEY_ID
       key-secret: $AWS_SECRET_ACCESS_KEY
       file: ./${DESTINATION_DIR_NAME}
-      url: s3://asha-fusion-archive/desktop/
+      url: s3://${S3_BUCKET_DEPLOY_TO}/${S3_PREFIX}/
 
 deploy-debug:
   steps:


### PR DESCRIPTION
ASHA fusion is built for web and desktop app then these are deployed to AWS S3 automatically via CI.
In this PR, the target S3 Bucket and prefix are changed to be variables to be set dynamically (See wercker CI workflows (`web-build-and-upload` and `electron-build-and-upload`: https://app.wercker.com/tuttieee/AshaFusionCross/workflows )