### PR TITLE
(refs #518) Add hashes to resultant file names for cache busting

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -7,6 +7,8 @@ const HtmlWebpackExcludeAssetsPlugin = require('html-webpack-exclude-assets-plug
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const isProd = process.env.NODE_ENV === 'production';
+
 module.exports = {
   entry: [
     'babel-polyfill',
@@ -42,7 +44,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 1024,
-          name: 'assets/img/[name].[ext]',
+          name: 'assets/img/[name]-[hash].[ext]',
         },
       },
       {
@@ -84,7 +86,7 @@ module.exports = {
   },
   plugins: [
     new ExtractTextPlugin({
-      filename: 'style.css',
+      filename: isProd ? 'style-[hash].css' : 'style.css',
       allChunks: true,
     }),
     new HtmlWebpackPlugin({
@@ -102,7 +104,7 @@ module.exports = {
   devtool: '#eval-source-map',
 };
 
-if (process.env.NODE_ENV === 'production') {
+if (isProd) {
   module.exports.devtool = '#source-map';
   module.exports.plugins = (module.exports.plugins || []).concat([
     new webpack.LoaderOptionsPlugin({

--- a/webpack.config.web.js
+++ b/webpack.config.web.js
@@ -5,9 +5,11 @@ const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 
 const baseConfig = require('./webpack.config.base');
 
+const isProd = process.env.NODE_ENV === 'production';
+
 module.exports = merge(baseConfig, {
   output: {
-    filename: 'app.js',
+    filename: isProd ? 'app-[hash].js' : 'app.js',
     path: path.resolve('./public'),
     publicPath: '/',
   },
@@ -28,7 +30,7 @@ module.exports = merge(baseConfig, {
   },
 });
 
-if (process.env.NODE_ENV === 'production') {
+if (isProd) {
   module.exports.plugins = (module.exports.plugins || []).concat([
     new FaviconsWebpackPlugin({
       logo: path.resolve('./assets/img/logo.svg'),


### PR DESCRIPTION
Fix webpack configurations to generate files with hashed file names like `app-f6743ced01bb85a7e139.js`, but not `app.js` for cache busting.
ref: https://css-tricks.com/strategies-for-cache-busting-css/