### PR TITLE
(refs #547) Update checkVisibility to handle an empty array as falsy

### DIFF
--- a/src/web/forms/__tests__/utils-test.js
+++ b/src/web/forms/__tests__/utils-test.js
@@ -53,6 +53,16 @@ describe('checkVisibility', () => {
     expect(checkVisibility(state, 'root', 'foo:bbb')).toBe(false);
   });
 
+  it('handles an empty array as falthy', () => {
+    const state = {
+      root: {
+        foo: [],
+      },
+    };
+
+    expect(checkVisibility(state, 'root', 'foo')).toBe(false);
+  });
+
   it('handles empty rootPath', () => {
     const state = {
       foo: true,

--- a/src/web/forms/utils.js
+++ b/src/web/forms/utils.js
@@ -37,6 +37,11 @@ export function checkVisibility(state: Object, rootPath: ?string, showProp: stri
         }
         return referent === valueToCheck;
       }
+
+      if (Array.isArray(referent)) {
+        return referent.length > 0;
+      }
+
       return !!referent;
     });
   }


### PR DESCRIPTION
- "show" property (for example, https://github.com/asha-nepal/AshaFusionCross/blob/master/src/store/reducers/dform/initial/styles.json#L365) controls the visibility of the field.
  - The value of "show" prop is a path of another field whose value is to be referred.
- By this PR, it becomes possible to set a "show" prop to refer to a field whose value is an `Array`.
  - An empty array (`[]`) is handled as falsy (different from JS behavior)
  - not empty array (e.g. `["some-value"]`) is handled as truthy

