### PR TITLE
(refs #564) Update checkVisibility to deal with "!" sign

### DIFF
--- a/src/web/forms/__tests__/utils-test.js
+++ b/src/web/forms/__tests__/utils-test.js
@@ -85,4 +85,31 @@ describe('checkVisibility', () => {
 
     expect(checkVisibility(state, 'root', 'foo|bar')).toBe(true);
   });
+
+  it('handles negative', () => {
+    const state = {
+      root: {
+        foo: {
+          bar: true,
+        },
+        hoge: {
+          fuga: false,
+        },
+      },
+    };
+
+    expect(checkVisibility(state, 'root', '!foo.bar')).toBe(false);
+    expect(checkVisibility(state, 'root', '!hoge.fuga')).toBe(true);
+  });
+
+  it('handles negative on Array referent', () => {
+    const state = {
+      root: {
+        foo: ['aaa', 'zzz'],
+      },
+    };
+
+    expect(checkVisibility(state, 'root', '!foo:aaa')).toBe(false);
+    expect(checkVisibility(state, 'root', '!foo:bbb')).toBe(true);
+  });
 });


### PR DESCRIPTION
# Background
The visibility of each field in the form can be controlled by setting `show` prop to it like https://github.com/asha-nepal/AshaFusionCross/blob/master/src/store/reducers/dform/initial/styles.json#L365

For example,

```
        {
          "field": "allergy_memo",
          "label": "Allergy memo",
          "class": "textarea",
          "show": "allergy"
        },
```

the code above means "the field `allergy_memo` appears when the value of `allergy` is `true` and doesn't if the value is `false`".

Now, it is required to be able to set the "Inverse" of boolean to the `show` prop like `"!allergy"` so that it works conversely.

# Changes in this PR
Fix `checkVisibility` function, which parses `show` prop and determines the visibility of the field, to be able to deal with `!` sign as inversion of a boolean value.