### PR TITLE
(refs #570) Add .is-width-restricted

### DIFF
--- a/src/web/forms/fields/CheckGroup.js
+++ b/src/web/forms/fields/CheckGroup.js
@@ -59,7 +59,7 @@ export const CheckGroupComponent = ({
   readonly ? (
     <ReadOnly value={value} options={options} />
   ) : (
-    <div className="buttons">
+    <div className="buttons is-width-restricted">
       {options.map(option => {
         const isChecked = value && value.indexOf(option.id) > -1;
         return (

--- a/src/web/sass/buttons.sass
+++ b/src/web/sass/buttons.sass
@@ -2,3 +2,13 @@
   &.is-equiv
     *
       flex-grow: 1
+
+  &.is-width-restricted
+    +from($tablet)
+      max-width: $tablet - (2 * $gap)
+    +from($desktop)
+      max-width: $desktop - (2 * $gap)
+    +from($widescreen)
+      max-width: $widescreen - (2 * $gap)
+    +from($fullhd)
+      max-width: $fullhd - (2 * $gap)


### PR DESCRIPTION
Set CSS to control the width of `.buttons` class, which fixes the bug below:
<img width="1250" alt="2018-01-22 19 21 21" src="https://user-images.githubusercontent.com/3135397/35216082-b69c4cc8-ffa9-11e7-9040-89dc59fde79d.png">
