### PR TITLE
(refs #568) Add border prop to Block field

### DIFF
--- a/src/web/forms/fields/Block.js
+++ b/src/web/forms/fields/Block.js
@@ -26,18 +26,20 @@ export const Block = ({
   label,
   children,
   widthaligned = false,
+  border = false,
   layout,
   fieldEditProps,
 }: {
   label?: string,
   children: React$Element<any>,
   widthaligned: boolean,
+  border: boolean,
   layout?: string,
   wrap?: boolean,
   fieldEditProps?: FieldEditPropsType,
 }): React$Element<any> => (
   <EditableFieldWrapper
-    className="field"
+    className={classNames('field', { box: border })}
     fieldEditProps={fieldEditProps}
   >
     {label && <label className="label">{label}</label>}
@@ -52,7 +54,7 @@ export const Block = ({
         <div
           key={i}
           className={classNames('column', { 'is-narrow': !widthaligned })}
-          style={widthaligned ? {} : { paddingBottom: 0 }}
+          style={(widthaligned || border) ? {} : { paddingBottom: 0 }}
         >
           {child}
         </div>


### PR DESCRIPTION
Fix `Block` component to accept `border` prop, which controls the view of the component:

`border: true` :
<img width="1212" alt="2018-01-22 19 18 37" src="https://user-images.githubusercontent.com/3135397/35215927-2dfb17e6-ffa9-11e7-9fa3-bab60b342677.png">

`border: false` :
<img width="1191" alt="2018-01-22 19 18 51" src="https://user-images.githubusercontent.com/3135397/35215929-2f272916-ffa9-11e7-9684-8be88b11fefa.png">
