### PR TITLE
(refs #586) Add size and shrink props to TextArea

### DIFF
--- a/src/web/forms/fields/TextArea.js
+++ b/src/web/forms/fields/TextArea.js
@@ -17,6 +17,7 @@
 /* @flow */
 
 import React from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { actions } from 'react-redux-form';
 import _get from 'lodash.get';
@@ -38,23 +39,39 @@ export const TextAreaComponent = ({
   placeholder,
   readonly = false,
   onChange,
+  size = '',
+  shrink = false,
+  maxRows = 5,
 }: {
   value: ?string,
   placeholder?: string,
   readonly?: boolean,
   onChange: (newValue: string) => void,
-}) => (readonly ? (
-  <ReadonlyTextArea value={value} />
-) : (
-  <div className="control">
-    <textarea
-      className="textarea"
-      placeholder={placeholder}
-      value={value || ''}
-      onChange={e => onChange(e.target.value)}
-    />
-  </div>
-));
+  size: string,
+  shrink: boolean,
+  maxRows: number,
+}) => {
+  if (readonly) return <ReadonlyTextArea value={value} />;
+
+  const _value = value || '';
+
+  return (
+    <div className="control">
+      <textarea
+        className={classNames(
+          'textarea',
+          {
+            [`is-${size}`]: size,
+          }
+        )}
+        placeholder={placeholder}
+        value={_value}
+        onChange={e => onChange(e.target.value)}
+        rows={shrink ? Math.min(maxRows, _value.match(/^/mg).length) : null}
+      />
+    </div>
+  );
+};
 
 TextAreaComponent.fieldProps = [];
 

--- a/src/web/forms/fields/__tests__/TextArea-test.js
+++ b/src/web/forms/fields/__tests__/TextArea-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2018 Yuichiro Tsuchiya
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env jest */
+
+jest.unmock('react-redux');
+jest.unmock('../TextArea');
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { TextAreaComponent } from '../TextArea';
+
+describe('<TextArea />', () => {
+  it('changes the number of rows according to the input text if `shrink` prop is true', () => {
+    const text = 'Lorem\nipsum\ndolor';
+
+    const wrapper = shallow(
+      <TextAreaComponent
+        value={text}
+        shrink
+      />
+    );
+
+    expect(wrapper.find('textarea').prop('rows')).toBe(3);
+  });
+
+  it('limits the number of rows when `shrink` prop is true', () => {
+    const text = 'Lorem\nipsum\ndolor\nsit\namet,\nconsectetur\nadipisicing\nelit';
+
+    const wrapper = shallow(
+      <TextAreaComponent
+        value={text}
+        shrink
+      />
+    );
+
+    expect(wrapper.find('textarea').prop('rows')).toBe(5);
+  });
+});


### PR DESCRIPTION
Add 2 new props to `TextArea` component:

- `size`
  - which controls the size of the component
  -  <img width="736" alt="2018-02-12 16 59 45" src="https://user-images.githubusercontent.com/3135397/36087528-25ef34ce-1016-11e8-8d0f-08a102140b67.png">
- `shrink`
  - which changes the height of the component according to the number of lines
  - <img width="973" alt="2018-02-12 16 58 05" src="https://user-images.githubusercontent.com/3135397/36087489-f840e36a-1015-11e8-9f6e-792d85f60ceb.png">
